### PR TITLE
Update go-powerdns supporting configurable base path

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/libdns/powerdns/txtsanitize"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/libdns/libdns"
@@ -20,7 +19,7 @@ type client struct {
 
 func newClient(ServerID, ServerURL, APIToken string, debug io.Writer) (*client, error) {
 	if debug == nil {
-		debug = ioutil.Discard
+		debug = io.Discard
 	}
 	c, err := pdns.New(
 		pdns.WithBaseURL(ServerURL),

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/libdns/powerdns
 go 1.16
 
 require (
-	github.com/libdns/libdns v0.2.1
-	github.com/mittwald/go-powerdns v0.5.2
+	github.com/libdns/libdns v0.2.2
+	github.com/mittwald/go-powerdns v0.6.3
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,12 @@ github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslC
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/libdns/libdns v0.2.1 h1:Wu59T7wSHRgtA0cfxC+n1c/e+O3upJGWytknkmFEDis=
 github.com/libdns/libdns v0.2.1/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
+github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 github.com/mittwald/go-powerdns v0.5.2 h1:kfqr9ZNIuxOjjBaoJcOFiy/19VmKEUgfJPmObDglPJU=
 github.com/mittwald/go-powerdns v0.5.2/go.mod h1:bI/sZBAWyTViDknOTp19VfDxVEnh1U7rWPx2aRKtlzg=
+github.com/mittwald/go-powerdns v0.6.3 h1:t7HhWNosL+To+gJ+K4TRh1sZiFtB64ZrRlVvKPkpRGw=
+github.com/mittwald/go-powerdns v0.6.3/go.mod h1:adWJ860laOgm14afg+7V0nCa5NQT37oEYe2HRhoS/CA=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
The go-powerdns library added support for configurable base path instead of using hard coded path `/api/v1`. This way somebody can provide the full base url to use. If it does not contain a path or the path equals `/` it'll automatically use the default `/api/v1` like it does now. Otherwise it'll use the base path provided.

See also: https://github.com/mittwald/go-powerdns/issues/20